### PR TITLE
修复调用setChecked后，添加/删除按钮没有变化的bug

### DIFF
--- a/npm/transfer-extend-next/components/transfer.vue
+++ b/npm/transfer-extend-next/components/transfer.vue
@@ -1100,6 +1100,8 @@ export default {
      * @param {Array} rightKeys 右侧ids
      */
     setChecked(leftKeys = [], rightKeys = []) {
+      this.from_disabled = leftKeys.length<=0;
+      this.to_disabled = rightKeys.length<=0;
       this.$refs["from-tree"].setCheckedKeys(leftKeys);
       this.$refs["to-tree"].setCheckedKeys(rightKeys);
     },


### PR DESCRIPTION
最近在开发过程中发现，当调用setChecked方法设置选中左右树的节点后，树中间的添加和删除按钮依然是不可选的，故而有此commit，代码已经测试通过，请审核。